### PR TITLE
POST processing: see documentation for CLIENT-CONTENT-FILTER filter

### DIFF
--- a/actionlist.h
+++ b/actionlist.h
@@ -130,6 +130,7 @@ DEFINE_CGI_PARAM_RADIO   ("set-image-blocker",          ACTION_IMAGE_BLOCKER,   
 DEFINE_CGI_PARAM_RADIO   ("set-image-blocker",          ACTION_IMAGE_BLOCKER,   ACTION_STRING_IMAGE_BLOCKER, "blank", 0)
 DEFINE_CGI_PARAM_CUSTOM  ("set-image-blocker",          ACTION_IMAGE_BLOCKER,   ACTION_STRING_IMAGE_BLOCKER,  CGI_PREFIX "send-banner?type=pattern")
 DEFINE_ACTION_MULTI      ("suppress-tag",               ACTION_MULTI_SUPPRESS_TAG)
+DEFINE_ACTION_MULTI      ("client-content-filter",      ACTION_MULTI_CLIENT_CONTENT_FILTER)
 
 #if DEFINE_ACTION_ALIAS
 

--- a/actions.c
+++ b/actions.c
@@ -1117,6 +1117,8 @@ static const char *filter_type_to_string(enum filter_type filter_type)
 #endif
    case FT_SUPPRESS_TAG:
       return "suppress tag filter";
+   case FT_CLIENT_CONTENT_FILTER:
+      return "client content filter";
    case FT_INVALID_FILTER:
       return "invalid filter type";
    }
@@ -1187,7 +1189,8 @@ static int action_spec_is_valid(struct client_state *csp, const struct action_sp
       {ACTION_MULTI_CLIENT_HEADER_FILTER, FT_CLIENT_HEADER_FILTER},
       {ACTION_MULTI_SERVER_HEADER_FILTER, FT_SERVER_HEADER_FILTER},
       {ACTION_MULTI_CLIENT_HEADER_TAGGER, FT_CLIENT_HEADER_TAGGER},
-      {ACTION_MULTI_SERVER_HEADER_TAGGER, FT_SERVER_HEADER_TAGGER}
+      {ACTION_MULTI_SERVER_HEADER_TAGGER, FT_SERVER_HEADER_TAGGER},
+      {ACTION_MULTI_CLIENT_CONTENT_FILTER, FT_CLIENT_CONTENT_FILTER}
    };
    int errors = 0;
    int i;

--- a/cgiedit.c
+++ b/cgiedit.c
@@ -240,6 +240,18 @@ static const struct filter_type_info filter_type_info[] =
       "server-header-tagger-all", "server_header_tagger_all",
       "E", "SERVER-HEADER-TAGGER"
    },
+   {
+      ACTION_MULTI_SUPPRESS_TAG,
+      "suppress-tag-params", "suppress-tag",
+      "suppress-tag-all", "suppress_tag_all",
+      "U", "SUPPRESS-TAG"
+   },
+   {
+      ACTION_MULTI_CLIENT_CONTENT_FILTER,
+      "client-content-filter-params", "client-content-filter",
+      "client-content-filter-all", "client_content_filter_all",
+      "P", "CLIENT-CONTENT-FILTER"
+   },
 #ifdef FEATURE_EXTERNAL_FILTERS
    {
       ACTION_MULTI_EXTERNAL_FILTER,
@@ -248,12 +260,6 @@ static const struct filter_type_info filter_type_info[] =
       "E", "EXTERNAL-CONTENT-FILTER"
    },
 #endif
-   {
-      ACTION_MULTI_SUPPRESS_TAG,
-      "suppress-tag-params", "suppress-tag",
-      "suppress-tag-all", "suppress_tag_all",
-      "U", "SUPPRESS-TAG"
-   },
 };
 
 /* FIXME: Following non-static functions should be prototyped in .h or made static */
@@ -3186,6 +3192,9 @@ jb_err cgi_edit_actions_submit(struct client_state *csp,
             break;
          case 'E':
             multi_action_index = ACTION_MULTI_SERVER_HEADER_TAGGER;
+            break;
+         case 'P':
+            multi_action_index = ACTION_MULTI_CLIENT_CONTENT_FILTER;
             break;
          default:
             log_error(LOG_LEVEL_ERROR,

--- a/default.filter
+++ b/default.filter
@@ -906,3 +906,12 @@ s@^X-Privoxy-Control:\s*@@i
 SERVER-HEADER-FILTER: privoxy-control Removes X-Privoxy-Control headers.
 
 s@^X-Privoxy-Control:.*@@i
+
+#################################################################################
+#
+# empty-client-text-content: Empty client request text content
+#
+#################################################################################
+CLIENT-CONTENT-FILTER: empty-client-text-content Empty client request text content
+
+s@^.*$@@sm

--- a/doc/source/user-manual.sgml
+++ b/doc/source/user-manual.sgml
@@ -2955,6 +2955,94 @@ example.org/blocked-example-page</screen>
 </variablelist>
 </sect3>
 
+<!--   ~~~~~       New section      ~~~~~     -->
+<sect3 renderas="sect4" id="client-content-filter">
+<title>client-content-filter</title>
+
+<variablelist>
+ <varlistentry>
+  <term>Typical use:</term>
+  <listitem>
+   <para>
+   Rewrite or remove client request text content.
+   </para>
+  </listitem>
+ </varlistentry>
+
+ <varlistentry>
+  <term>Effect:</term>
+  <listitem>
+   <para>
+    The request text content to which this action applies are filtered on-the-fly through
+    the specified regular expression based substitutions.
+   </para>
+  </listitem>
+ </varlistentry>
+
+ <varlistentry>
+  <term>Type:</term>
+  <!-- boolean, parameterized, Multi-value -->
+  <listitem>
+   <para>Multi-value.</para>
+  </listitem>
+ </varlistentry>
+
+ <varlistentry>
+  <term>Parameter:</term>
+  <listitem>
+   <para>
+    The name of a client-content filter, as defined in one of the
+    <link linkend="filter-file">filter files</link>.
+   </para>
+  </listitem>
+ </varlistentry>
+
+ <varlistentry>
+  <term>Notes:</term>
+  <listitem>
+   <para>
+    The following request content is filtered:
+    <itemizedlist>
+     <listitem>
+      <para>
+       All values of the "application/x-www-form-urlencoded" content.
+      </para>
+     </listitem>
+     <listitem>
+      <para>
+       Text files and all form values in "multipart/form-data" content (i.e. binary files are ignored).
+      </para>
+     </listitem>
+     <listitem>
+      <para>
+       If the request content type is text then the whole content is filtered.
+      </para>
+     </listitem>
+    </itemizedlist>
+   </para>
+   <para>
+    Please refer to the <link linkend="filter-file">filter file chapter</link>
+    to learn which client-content filters are available by default, and how to
+    create your own.
+   </para>
+
+  </listitem>
+ </varlistentry>
+
+ <varlistentry>
+  <term>Example usage (section):</term>
+  <listitem>
+     <screen>
+# Empty client request text content
+{+client-content-filter{empty-client-text-content}}
+/
+</screen>
+  </listitem>
+ </varlistentry>
+
+</variablelist>
+</sect3>
+
 
 <!--   ~~~~~       New section      ~~~~~     -->
 <sect3 renderas="sect4" id="client-header-tagger">
@@ -6889,9 +6977,11 @@ stupid-server.example.com/</screen>
  <literal><link linkend="filter">filter</link></literal> to
  rewrite the content that is send to the client,
  <literal><link linkend="client-header-filter">client-header-filter</link></literal>
- to rewrite headers that are send by the client, and
+ to rewrite headers that are send by the client,
  <literal><link linkend="server-header-filter">server-header-filter</link></literal>
- to rewrite headers that are send by the server.
+ to rewrite headers that are send by the server, and
+ <literal><link linkend="client-content-filter">client-content-filter</link></literal>
+ to rewrite client request text content
 </para>
 
 <para>
@@ -6950,7 +7040,8 @@ stupid-server.example.com/</screen>
  filter file is organized in sections, which are called <emphasis>filters</emphasis>
  here. Each filter consists of a heading line, that starts with one of the
  <emphasis>keywords</emphasis> <literal>FILTER:</literal>,
- <literal>CLIENT-HEADER-FILTER:</literal> or <literal>SERVER-HEADER-FILTER:</literal>
+ <literal>CLIENT-HEADER-FILTER:</literal>, <literal>SERVER-HEADER-FILTER:</literal> or
+ <literal>CLIENT-CONTENT-FILTER:</literal>
  followed by the filter's <emphasis>name</emphasis>, and a short (one line)
  <emphasis>description</emphasis> of what it does. Below that line
  come the <emphasis>jobs</emphasis>, i.e. lines that define the actual

--- a/filters.c
+++ b/filters.c
@@ -1537,25 +1537,34 @@ struct re_filterfile_spec *get_filter(const struct client_state *csp,
 
 /*********************************************************************
  *
- * Function    :  pcrs_filter_response
+ * Function    :  pcrs_filter_impl
  *
  * Description :  Execute all text substitutions from all applying
- *                +filter actions on the text buffer that's been
- *                accumulated in csp->iob->buf.
+ *                (based on filter_response_body value) +filter
+ *                or +client_content_filter actions on the given text buffer
  *
  * Parameters  :
  *          1  :  csp = Current client state (buffers, headers, etc...)
+ *          2  :  data = filter_response_body when TRUE execute +filter
+ *                actions; execute +client_content_filter actions otherwise
+ *          3  :  data = Target data
+ *          4  :  data_len = Target data len
  *
  * Returns     :  a pointer to the (newly allocated) modified buffer.
  *                or NULL if there were no hits or something went wrong
  *
  *********************************************************************/
-static char *pcrs_filter_response(struct client_state *csp)
+static char *pcrs_filter_impl(struct client_state *csp, int filter_response_body,
+                              const char *data, size_t *data_len)
 {
    int hits = 0;
    size_t size, prev_size;
+   const int filters_idx =
+      filter_response_body ? ACTION_MULTI_FILTER : ACTION_MULTI_CLIENT_CONTENT_FILTER;
+   const enum filter_type filter_type =
+      filter_response_body ? FT_CONTENT_FILTER : FT_CLIENT_CONTENT_FILTER;
 
-   char *old = NULL;
+   const char *old = NULL;
    char *new = NULL;
    pcrs_job *job;
 
@@ -1565,7 +1574,7 @@ static char *pcrs_filter_response(struct client_state *csp)
    /*
     * Sanity first
     */
-   if (csp->iob->cur >= csp->iob->eod)
+   if (*data_len == 0)
    {
       return(NULL);
    }
@@ -1577,15 +1586,15 @@ static char *pcrs_filter_response(struct client_state *csp)
       return(NULL);
    }
 
-   size = (size_t)(csp->iob->eod - csp->iob->cur);
-   old = csp->iob->cur;
+   size = *data_len;
+   old = data;
 
    /*
-    * For all applying +filter actions, look if a filter by that
+    * For all applying actions, look if a filter by that
     * name exists and if yes, execute it's pcrs_joblist on the
     * buffer.
     */
-   for (filtername = csp->action->multi[ACTION_MULTI_FILTER]->first;
+   for (filtername = csp->action->multi[filters_idx]->first;
         filtername != NULL; filtername = filtername->next)
    {
       int current_hits = 0; /* Number of hits caused by this filter */
@@ -1593,7 +1602,7 @@ static char *pcrs_filter_response(struct client_state *csp)
       int job_hits     = 0; /* How many hits the current job caused */
       pcrs_job *joblist;
 
-      b = get_filter(csp, filtername->str, FT_CONTENT_FILTER);
+      b = get_filter(csp, filtername->str, filter_type);
       if (b == NULL)
       {
          continue;
@@ -1624,7 +1633,7 @@ static char *pcrs_filter_response(struct client_state *csp)
              * input for the next one.
              */
             current_hits += job_hits;
-            if (old != csp->iob->cur)
+            if (old != data)
             {
                freez(old);
             }
@@ -1656,9 +1665,18 @@ static char *pcrs_filter_response(struct client_state *csp)
 
       if (b->dynamic) pcrs_free_joblist(joblist);
 
-      log_error(LOG_LEVEL_RE_FILTER,
-         "filtering %s%s (size %lu) with \'%s\' produced %d hits (new size %lu).",
-         csp->http->hostport, csp->http->path, prev_size, b->name, current_hits, size);
+      if (filter_response_body)
+      {
+         log_error(LOG_LEVEL_RE_FILTER,
+            "filtering %s%s (size %lu) with \'%s\' produced %d hits (new size %lu).",
+            csp->http->hostport, csp->http->path, prev_size, b->name, current_hits, size);
+      }
+      else
+      {
+         log_error(LOG_LEVEL_RE_FILTER,
+            "filtering client %s request (size %lu) with \'%s\' produced %d hits (new size %lu).",
+            csp->ip_addr_str, prev_size, b->name, current_hits, size);
+      }
 #ifdef FEATURE_EXTENDED_STATISTICS
       update_filter_statistics(b->name, current_hits);
 #endif
@@ -1667,11 +1685,11 @@ static char *pcrs_filter_response(struct client_state *csp)
 
    /*
     * If there were no hits, destroy our copy and let
-    * chat() use the original in csp->iob
+    * chat() use the original content
     */
    if (!hits)
    {
-      if (old != csp->iob->cur && old != new)
+      if (old != data && old != new)
       {
          freez(old);
       }
@@ -1679,12 +1697,50 @@ static char *pcrs_filter_response(struct client_state *csp)
       return(NULL);
    }
 
-   csp->flags |= CSP_FLAG_MODIFIED;
-   csp->content_length = size;
-   clear_iob(csp->iob);
+   *data_len = size;
+   return(new);
+}
+
+
+/*********************************************************************
+ *
+ * Function    :  pcrs_filter_response_body
+ *
+ * Description :  Execute all text substitutions from all applying
+ *                +filter actions on the text buffer that's been
+ *                accumulated in csp->iob->buf.
+ *
+ * Parameters  :
+ *          1  :  csp = Current client state (buffers, headers, etc...)
+ *
+ * Returns     :  a pointer to the (newly allocated) modified buffer.
+ *                or NULL if there were no hits or something went wrong
+ *
+ *********************************************************************/
+static char *pcrs_filter_response_body(struct client_state *csp)
+{
+   size_t size = (size_t)(csp->iob->eod - csp->iob->cur);
+
+   char *new = NULL;
+
+   /*
+    * Sanity first
+    */
+   if (csp->iob->cur >= csp->iob->eod)
+   {
+      return(NULL);
+   }
+
+   new = pcrs_filter_impl(csp, TRUE, csp->iob->cur, &size);
+
+   if (new != NULL)
+   {
+      csp->flags |= CSP_FLAG_MODIFIED;
+      csp->content_length = size;
+      clear_iob(csp->iob);
+   }
 
    return(new);
-
 }
 
 
@@ -1917,6 +1973,28 @@ static char *execute_external_filter(const struct client_state *csp,
 
 /*********************************************************************
  *
+ * Function    :  pcrs_filter_request_body
+ *
+ * Description :  Execute all text substitutions from all applying
+ *                +client_content_filter actions on the given text buffer
+ *
+ * Parameters  :
+ *          1  :  csp = Current client state (buffers, headers, etc...)
+ *          2  :  data = Target data
+ *          3  :  data_len = Target data len
+ *
+ * Returns     :  a pointer to the (newly allocated) modified buffer.
+ *                or NULL if there were no hits or something went wrong
+ *
+ *********************************************************************/
+static char *pcrs_filter_request_body(struct client_state *csp, const char *data, size_t *data_len)
+{
+   return pcrs_filter_impl(csp, FALSE, data, data_len);
+}
+
+
+/*********************************************************************
+ *
  * Function    :  gif_deanimate_response
  *
  * Description :  Deanimate the GIF image that has been accumulated in
@@ -2003,7 +2081,7 @@ static filter_function_ptr get_filter_function(const struct client_state *csp)
    if ((csp->content_type & CT_TEXT) &&
        (!list_is_empty(csp->action->multi[ACTION_MULTI_FILTER])))
    {
-      filter_function = pcrs_filter_response;
+      filter_function = pcrs_filter_response_body;
    }
    else if ((csp->content_type & CT_GIF) &&
             (csp->action->flags & ACTION_DEANIMATE))
@@ -2298,6 +2376,331 @@ char *execute_content_filters(struct client_state *csp)
 
    return content;
 
+}
+
+
+/*********************************************************************
+ *
+ * Function    :  multipart_content_type_text
+ *
+ * Description :  Checks if the given multipart content headers denote text.
+ *
+ * Parameters  :
+ *          1  :  headers_start = form part headers start
+ *          2  :  headers_end = form part headers end
+ *
+ * Returns     :  1 if no content type is set or content type is text
+ *                0 otherwise
+ *
+ *********************************************************************/
+static int multipart_content_type_text(const char *headers_start, const char *headers_end)
+{
+   static const char content_type[] = "Content-Type:";
+
+   const char *ct_start = strnstr(headers_start, content_type,
+                                  (size_t)(headers_end - headers_start));
+   const char *ct_end;
+
+   if (!ct_start)
+   {
+      return 1;
+   }
+
+   ct_start += sizeof(content_type) - 1;
+   ct_end = strnstr(ct_start, "\r\n", (size_t)(headers_end - ct_start));
+   /* filter_miltipart_form_data() implementation guarantees that there must be end marker! */
+   assert(ct_end);
+
+   return strnstr(ct_start, "text", (size_t)(ct_end - ct_start)) != NULL;
+}
+
+
+/*********************************************************************
+ *
+ * Function    :  filter_urlencoded_form_data
+ *
+ * Description :  Executes a given client content filter for
+ *                application/x-www-form-urlencoded form data.
+ *                Upon success moves client_iob cur pointer to the end of
+ *                the form data.
+ *
+ * Parameters  :
+ *          1  :  csp = Current client state (buffers, headers, etc...)
+ *          2  :  content_length = content length. Upon successful filtering
+ *                the passed value is updated with the new content length.
+ *
+ * Returns     :  Pointer to the modified buffer, or
+ *                NULL if filtering failed or wasn't necessary.
+ *
+ *********************************************************************/
+static char *filter_urlencoded_form_data(struct client_state *csp, size_t *content_length)
+{
+   size_t len;
+   const char *tmp = NULL;
+   char *params = NULL;
+   char *ret = NULL;
+   struct map *parsed = NULL;
+   const struct map_entry *cur_entry;
+   struct iob dest = {0};
+
+   /* copy original data: parse_url_encoded_string() will trash it */
+   len = *content_length + 1;
+   params = malloc_or_die(len);
+   memcpy(params, csp->client_iob->cur, len);
+   params[len - 1] = 0;
+
+   parsed = parse_url_encoded_string(params);
+   if (parsed == NULL)
+   {
+      log_error(LOG_LEVEL_RE_FILTER, "Can not parse urlencoded data");
+      goto error;
+   }
+
+   for (cur_entry = parsed->first; cur_entry != NULL; cur_entry = cur_entry->next)
+   {
+      size_t value_len = strlen(cur_entry->value);
+      char *filtered;
+
+      tmp = url_encode(cur_entry->name);
+      if (add_to_iob(&dest, csp->config->buffer_limit, tmp, (long)strlen(tmp)))
+      {
+         goto error;
+      }
+      freez(tmp);
+      if (add_to_iob(&dest, csp->config->buffer_limit, "=", 1))
+      {
+         goto error;
+      }
+      filtered = pcrs_filter_request_body(csp, cur_entry->value, &value_len);
+      if (filtered == NULL)
+      {
+         tmp = url_encode(cur_entry->value);
+      }
+      else
+      {
+         tmp = url_encode(filtered);
+         value_len = strlen(tmp);
+      }
+      if (tmp == NULL)
+      {
+         log_error(LOG_LEVEL_RE_FILTER, "Can not urlencode data %s",
+            filtered == NULL ? cur_entry->value : filtered);
+         goto error;
+      }
+      if (filtered != NULL)
+      {
+         freez(filtered);
+      }
+      if (add_to_iob(&dest, csp->config->buffer_limit, tmp, (long)value_len))
+      {
+         goto error;
+      }
+
+      if (cur_entry->next != NULL && add_to_iob(&dest, csp->config->buffer_limit, "&", 1))
+      {
+         goto error;
+      }
+      freez(tmp);
+   }
+
+   if (add_to_iob(&dest, csp->config->buffer_limit, "\r\n", 2))
+   {
+      goto error;
+   }
+
+   csp->client_iob->cur += *content_length;
+   *content_length = (unsigned long long)(dest.eod - dest.buf);
+   ret = dest.buf;
+   dest.buf = NULL;
+
+error:
+   freez(params);
+   freez(tmp);
+   free_map(parsed);
+   freez(dest.buf);
+   return ret;
+}
+
+
+/*********************************************************************
+ *
+ * Function    :  filter_miltipart_form_data
+ *
+ * Description :  Executes a given client content filter for multipart form data.
+ *                Upon success moves client_iob cur pointer to the end of
+ *                the form data.
+ *
+ * Parameters  :
+ *          1  :  csp = Current client state (buffers, headers, etc...)
+ *          2  :  content_length = content length. Upon successful filtering
+ *                the passed value is updated with the new content length.
+ *
+ * Returns     :  Pointer to the modified buffer, or
+ *                NULL if filtering failed or wasn't necessary.
+ *
+ *********************************************************************/
+static char *filter_miltipart_form_data(struct client_state *csp, size_t *content_length)
+{
+   const char *bound_param = csp->multipart_form_boundary_start;
+   size_t bound_len = strlen(csp->multipart_form_boundary_start);
+   const char *old_pos = csp->client_iob->cur;
+   const char *pos;
+   struct iob dest = {0};
+
+   char bound[bound_len + 5];
+
+   if (bound_param[0] == '"')
+   {
+      if (bound_len < 3 || bound_param[bound_len - 1] != '"')
+      {
+         log_error(LOG_LEVEL_RE_FILTER, "Error filtering multipart form data: invalid boundary [%s]", bound);
+         return NULL;
+      }
+      bound_param++;
+      bound_len--;
+   }
+
+   if (snprintf(bound, sizeof(bound), "\r\n--%.*s", (int)bound_len, bound_param) < 0)
+   {
+      log_error(LOG_LEVEL_RE_FILTER, "Error during bound constrution [%s]", bound_param);
+      return NULL;
+   }
+
+   bound_len += 4;
+
+   pos = strstr(old_pos, bound + 2);
+   if (pos == NULL)
+   {
+      log_error(LOG_LEVEL_RE_FILTER, "Error filtering multipart form data: can't find boundary");
+      return NULL;
+   }
+
+   for (pos += bound_len - 2; strncmp(pos, "--\r\n", 4); pos += bound_len)
+   {
+      const char *filtered_data;
+      const char *data_start;
+      size_t data_len;
+      int content_type_text;
+      jb_err error;
+
+      data_start = strstr(pos, "\r\n\r\n");
+      if (data_start == NULL)
+      {
+         log_error(LOG_LEVEL_RE_FILTER, "Error filtering multipart form data: can't find content start");
+         goto error;
+      }
+      data_start += 4;
+      content_type_text = multipart_content_type_text(pos, data_start);
+      pos = strstr(data_start, bound);
+      if (pos == NULL)
+      {
+         log_error(LOG_LEVEL_RE_FILTER, "Error filtering multipart form data: can't find content end");
+         goto error;
+      }
+      if (!content_type_text)
+      {
+         if (add_to_iob(&dest, csp->config->buffer_limit, old_pos, pos - old_pos))
+         {
+            goto error;
+         }
+         old_pos = pos;
+         continue;
+      }
+      if (add_to_iob(&dest, csp->config->buffer_limit, old_pos, data_start - old_pos))
+      {
+         goto error;
+      }
+      old_pos = pos;
+      data_len = (size_t)(pos - data_start);
+      filtered_data = pcrs_filter_request_body(csp, data_start, &data_len);
+      if (filtered_data == NULL)
+      {
+         if (add_to_iob(&dest, csp->config->buffer_limit, data_start, pos - data_start))
+         {
+            goto error;
+         }
+         continue;
+      }
+      error = add_to_iob(&dest, csp->config->buffer_limit, filtered_data, (long)data_len);
+      freez(filtered_data);
+      if (error)
+      {
+         goto error;
+      }
+   }
+
+   pos += 4;
+
+   if (add_to_iob(&dest, csp->config->buffer_limit, bound, (long)bound_len))
+   {
+      goto error;
+   }
+   if (add_to_iob(&dest, csp->config->buffer_limit, "--\r\n", 4))
+   {
+      goto error;
+   }
+
+   csp->client_iob->cur = (char *)pos;
+   *content_length = (unsigned long long)(dest.eod - dest.buf);
+   return dest.cur;
+
+error:
+   freez(dest.cur);
+   return NULL;
+}
+
+
+/*********************************************************************
+ *
+ * Function    :  execute_client_content_filters
+ *
+ * Description :  Executes a given client content filter.
+ *                Upon success moves client_iob cur pointer to the end of
+ *                the form data.
+ *
+ * Parameters  :
+ *          1  :  csp = Current client state (buffers, headers, etc...)
+ *          2  :  content_length = content length. Upon successful filtering
+ *                the passed value is updated with the new content length.
+ *
+ * Returns     :  Pointer to the modified buffer, or
+ *                NULL if filtering failed or wasn't necessary.
+ *
+ *********************************************************************/
+char *execute_client_content_filters(struct client_state *csp, size_t *content_length)
+{
+   char *ret;
+
+   assert(client_content_filters_enabled(csp->action));
+
+   if (content_length == 0)
+   {
+      /*
+       * No content, no filtering necessary.
+       */
+      return NULL;
+   }
+
+   if (csp->multipart_form_boundary_start != NULL)
+   {
+      return filter_miltipart_form_data(csp, content_length);
+   }
+   else if (csp->content_type & CT_URLENCODED)
+   {
+      return filter_urlencoded_form_data(csp, content_length);
+   }
+   else if ((csp->content_type & CT_TEXT) == 0)
+   {
+      return NULL;
+   }
+
+   /* CT_TEXT content */
+   ret = pcrs_filter_request_body(csp, csp->client_iob->cur, content_length);
+   if (ret != NULL)
+   {
+      csp->client_iob->cur = csp->client_iob->eod;
+   }
+   return ret;
 }
 
 
@@ -2721,6 +3124,25 @@ int content_filters_enabled(const struct current_action_spec *action)
    return ((action->flags & ACTION_DEANIMATE) ||
       !list_is_empty(action->multi[ACTION_MULTI_FILTER]) ||
       !list_is_empty(action->multi[ACTION_MULTI_EXTERNAL_FILTER]));
+}
+
+
+/*********************************************************************
+ *
+ * Function    :  client_content_filters_enabled
+ *
+ * Description :  Checks whether there are any client content filters
+ *                enabled for the current request.
+ *
+ * Parameters  :
+ *          1  :  action = Action spec to check.
+ *
+ * Returns     :  TRUE for yes, FALSE otherwise
+ *
+ *********************************************************************/
+int client_content_filters_enabled(const struct current_action_spec *action)
+{
+   return !list_is_empty(action->multi[ACTION_MULTI_CLIENT_CONTENT_FILTER]);
 }
 
 

--- a/filters.h
+++ b/filters.h
@@ -84,6 +84,7 @@ extern const struct forward_spec *forward_url(struct client_state *csp,
  * Content modification
  */
 extern char *execute_content_filters(struct client_state *csp);
+extern char *execute_client_content_filters(struct client_state *csp, size_t *filtered_data_len);
 extern char *execute_single_pcrs_command(char *subject, const char *pcrs_command, int *hits);
 extern char *rewrite_url(char *old_url, const char *pcrs_command);
 
@@ -91,6 +92,7 @@ extern pcrs_job *compile_dynamic_pcrs_job_list(const struct client_state *csp, c
 
 extern int content_requires_filtering(struct client_state *csp);
 extern int content_filters_enabled(const struct current_action_spec *action);
+extern int client_content_filters_enabled(const struct current_action_spec *action);
 extern int filters_available(const struct client_state *csp);
 
 /*

--- a/jcc.c
+++ b/jcc.c
@@ -1991,6 +1991,111 @@ static jb_err parse_client_request(struct client_state *csp)
 
 /*********************************************************************
  *
+ * Function    : read_http_post_data
+ *
+ * Description : Reads remaining POST data from the client
+ *
+ * Parameters  :
+ *          1  :  csp = Current client state (buffers, headers, etc...)
+ *
+ * Returns     :  0 on success, anything else is an error.
+ *
+ *********************************************************************/
+static int read_http_post_data(struct client_state *csp)
+{
+   size_t to_read = csp->expected_client_content_length;
+   int len;
+
+   assert(to_read != 0);
+
+   /* check if all data has been already read */
+   if (to_read <= (csp->client_iob->eod - csp->client_iob->cur))
+   {
+      return 0;
+   }
+
+   for (to_read -= (size_t)(csp->client_iob->eod - csp->client_iob->cur);
+        to_read > 0 && data_is_available(csp->cfd, csp->config->socket_timeout);
+        to_read -= (unsigned)len)
+   {
+      char buf[BUFFER_SIZE];
+      size_t max_bytes_to_read = to_read < sizeof(buf) ? to_read : sizeof(buf);
+
+      log_error(LOG_LEVEL_CONNECT,
+         "Waiting for up to %d bytes of POST data from the client.",
+         max_bytes_to_read);
+      len = read_socket(csp->cfd, buf, (int)max_bytes_to_read);
+      if (len <= -1)
+      {
+         log_error(LOG_LEVEL_CONNECT, "Failed receiving request body from %s", csp->ip_addr_str);
+         return 1;
+      }
+      if (add_to_iob(csp->client_iob, csp->config->buffer_limit, (char *)buf, len))
+      {
+         return 1;
+      }
+      assert(to_read >= len);
+   }
+
+   if (to_read != 0)
+   {
+      log_error(LOG_LEVEL_CONNECT, "Not enough post data has been read: expected %d more bytes",
+         csp->expected_client_content_length);
+      return 1;
+   }
+   log_error(LOG_LEVEL_CONNECT, "The last %d bytes of the post data has been read",
+      csp->expected_client_content_length);
+   return 0;
+}
+
+
+/*********************************************************************
+ *
+ * Function    : update_client_headers
+ *
+ * Description : Updates the HTTP headers from the client request
+ *
+ * Parameters  :
+ *          1  :  csp = Current client state (buffers, headers, etc...)
+ *
+ * Returns     :  0 on success, anything else is an error.
+ *
+ *********************************************************************/
+static int update_client_headers(struct client_state *csp, size_t new_content_length)
+{
+   static const char content_length[] = "Content-Length:";
+   int updated = 0;
+
+#ifndef FEATURE_HTTPS_INSPECTION
+   for (struct list_entry *p = csp->headers->first;
+#else
+   for (struct list_entry *p = csp->http->client_ssl ? csp->https_headers->first : csp->headers->first;
+#endif
+        !updated  && (p != NULL); p = p->next)
+   {
+      /* Header crunch()ed in previous run? -> ignore */
+      if (p->str == NULL)
+      {
+         continue;
+      }
+
+      /* Does the current parser handle this header? */
+      if (0 == strncmpic(p->str, content_length, sizeof(content_length) - 1))
+      {
+         updated = (JB_ERR_OK == header_adjust_content_length((char **)&(p->str), new_content_length));
+         if (!updated)
+         {
+            return 1;
+         }
+      }
+   }
+
+   return !updated;
+}
+
+
+/*********************************************************************
+ *
  * Function    : send_http_request
  *
  * Description : Sends the HTTP headers from the client request
@@ -2006,6 +2111,32 @@ static int send_http_request(struct client_state *csp)
 {
    char *hdr;
    int write_failure;
+   const char *to_send;
+   size_t to_send_len;
+   int filter_client_content = csp->expected_client_content_length != 0 &&
+      client_content_filters_enabled(csp->action);
+
+   if (filter_client_content)
+   {
+      if (read_http_post_data(csp))
+      {
+         return 1;
+      }
+      to_send_len = csp->expected_client_content_length;
+      to_send = execute_client_content_filters(csp, &to_send_len);
+      if (to_send == NULL)
+      {
+         /* just flush client_iob */
+         filter_client_content = FALSE;
+      }
+      else if (to_send_len != csp->expected_client_content_length &&
+         update_client_headers(csp, to_send_len))
+      {
+         log_error(LOG_LEVEL_HEADER, "Error updating client headers");
+         return 1;
+      }
+      csp->expected_client_content_length = 0;
+   }
 
    hdr = list_to_text(csp->headers);
    if (hdr == NULL)
@@ -2014,6 +2145,8 @@ static int send_http_request(struct client_state *csp)
       log_error(LOG_LEVEL_FATAL, "Out of memory parsing client header");
    }
    list_remove_all(csp->headers);
+   csp->multipart_form_boundary_start = NULL;
+   csp->content_type = 0;
 
    /*
     * Write the client's (modified) header to the server
@@ -2026,21 +2159,94 @@ static int send_http_request(struct client_state *csp)
    {
       log_error(LOG_LEVEL_CONNECT, "Failed sending request headers to: %s: %E",
          csp->http->hostport);
+      return 1;
    }
-   else if (((csp->flags & CSP_FLAG_PIPELINED_REQUEST_WAITING) == 0)
+
+   if (filter_client_content)
+   {
+      write_failure = 0 != write_socket(csp->server_connection.sfd, to_send, to_send_len);
+      freez(to_send);
+      if (write_failure)
+      {
+         log_error(LOG_LEVEL_CONNECT, "Failed sending filtered request body to: %s: %E",
+            csp->http->hostport);
+         return 1;
+      }
+   }
+
+   if (((csp->flags & CSP_FLAG_PIPELINED_REQUEST_WAITING) == 0)
       && (flush_iob(csp->server_connection.sfd, csp->client_iob, 0) < 0))
    {
-      write_failure = 1;
       log_error(LOG_LEVEL_CONNECT, "Failed sending request body to: %s: %E",
          csp->http->hostport);
+      return 1;
    }
-
-   return write_failure;
-
+   return 0;
 }
 
 
 #ifdef FEATURE_HTTPS_INSPECTION
+/*********************************************************************
+ *
+ * Function    : read_https_post_data
+ *
+ * Description : Reads remaining POST data from the client
+ *
+ * Parameters  :
+ *          1  :  csp = Current client state (buffers, headers, etc...)
+ *
+ * Returns     :  0 on success, anything else is an error.
+ *
+ *********************************************************************/
+static int read_https_post_data(struct client_state *csp)
+{
+   size_t to_read = csp->expected_client_content_length;
+   int len;
+
+   assert(to_read != 0);
+
+   /* check if all data has been already read */
+   if (to_read <= (csp->client_iob->eod - csp->client_iob->cur))
+   {
+      return 0;
+   }
+
+   for (to_read -= (size_t)(csp->client_iob->eod - csp->client_iob->cur);
+        to_read > 0 || is_ssl_pending(&(csp->ssl_client_attr));
+        to_read -= (unsigned)len)
+   {
+      unsigned char buf[BUFFER_SIZE];
+      size_t max_bytes_to_read = to_read < sizeof(buf) ? to_read : sizeof(buf);
+
+      log_error(LOG_LEVEL_CONNECT,
+         "Waiting for up to %d bytes of POST data from the client.",
+         max_bytes_to_read);
+      len = ssl_recv_data(&(csp->ssl_client_attr), buf,
+         (unsigned)max_bytes_to_read);
+      if (len <= 0)
+      {
+         log_error(LOG_LEVEL_CONNECT, "Failed receiving request body from %s", csp->ip_addr_str);
+         return 1;
+      }
+      if (add_to_iob(csp->client_iob, csp->config->buffer_limit, (char *)buf, len))
+      {
+         return 1;
+      }
+      assert(to_read >= len);
+   }
+
+   if (to_read != 0)
+   {
+      log_error(LOG_LEVEL_CONNECT, "Not enough post data has been read: expected %d more bytes", to_read);
+      return 1;
+   }
+
+   log_error(LOG_LEVEL_CONNECT, "The last %d bytes of the post data has been read",
+      csp->expected_client_content_length);
+   return 0;
+}
+
+
 /*********************************************************************
  *
  * Function    : receive_and_send_encrypted_post_data
@@ -2129,6 +2335,32 @@ static int send_https_request(struct client_state *csp)
    char *hdr;
    int ret;
    long flushed = 0;
+   const char *to_send;
+   size_t to_send_len;
+   int filter_client_content = csp->expected_client_content_length != 0 &&
+      client_content_filters_enabled(csp->action);
+
+   if (filter_client_content)
+   {
+      if (read_https_post_data(csp))
+      {
+         return 1;
+      }
+      to_send_len = csp->expected_client_content_length;
+      to_send = execute_client_content_filters(csp, &to_send_len);
+      if (to_send == NULL)
+      {
+         /* just flush client_iob */
+         filter_client_content = FALSE;
+      }
+      else if (to_send_len != csp->expected_client_content_length &&
+         update_client_headers(csp, to_send_len))
+      {
+         log_error(LOG_LEVEL_HEADER, "Error updating client headers");
+         return 1;
+      }
+      csp->expected_client_content_length = 0;
+   }
 
    hdr = list_to_text(csp->https_headers);
    if (hdr == NULL)
@@ -2137,6 +2369,8 @@ static int send_https_request(struct client_state *csp)
       log_error(LOG_LEVEL_FATAL, "Out of memory parsing client header");
    }
    list_remove_all(csp->https_headers);
+   csp->multipart_form_boundary_start = NULL;
+   csp->content_type = 0;
 
    /*
     * Write the client's (modified) header to the server
@@ -2153,6 +2387,18 @@ static int send_https_request(struct client_state *csp)
          csp->http->hostport);
       mark_server_socket_tainted(csp);
       return 1;
+   }
+
+   if (filter_client_content)
+   {
+      ret = ssl_send_data(&(csp->ssl_server_attr), (const unsigned char *)to_send, to_send_len);
+      freez(to_send);
+      if (ret < 0)
+      {
+         log_error(LOG_LEVEL_CONNECT, "Failed sending filtered request body to: %s: %E",
+            csp->http->hostport);
+         return 1;
+      }
    }
 
    if (((csp->flags & CSP_FLAG_PIPELINED_REQUEST_WAITING) == 0)
@@ -4262,6 +4508,7 @@ static void prepare_csp_for_next_request(struct client_state *csp)
    csp->content_length = 0;
    csp->expected_content_length = 0;
    csp->expected_client_content_length = 0;
+   csp->multipart_form_boundary_start = NULL;
    list_remove_all(csp->headers);
    clear_iob(csp->iob);
    freez(csp->error_message);

--- a/loaders.c
+++ b/loaders.c
@@ -1164,6 +1164,10 @@ int load_one_re_filterfile(struct client_state *csp, int fileid)
          new_filter = FT_EXTERNAL_CONTENT_FILTER;
       }
 #endif
+      else if (strncmp(buf, "CLIENT-CONTENT-FILTER:", 22) == 0)
+      {
+         new_filter = FT_CLIENT_CONTENT_FILTER;
+      }
 
       /*
        * If this is the head of a new filter block, make it a
@@ -1182,6 +1186,10 @@ int load_one_re_filterfile(struct client_state *csp, int fileid)
             new_bl->name = chomp(buf + 16);
          }
 #endif
+         else if (new_filter == FT_CLIENT_CONTENT_FILTER)
+         {
+            new_bl->name = chomp(buf + 22);
+         }
          else
          {
             new_bl->name = chomp(buf + 21);

--- a/parsers.c
+++ b/parsers.c
@@ -78,6 +78,7 @@
 #include "jcc.h"
 /* jcc.h is for mutex semapores only */
 #endif /* def FEATURE_PTHREAD */
+#include "encode.h"
 #include "list.h"
 #include "parsers.h"
 #include "ssplit.h"
@@ -144,6 +145,7 @@ static jb_err client_keep_alive(struct client_state *csp, char **header);
 static jb_err client_proxy_connection(struct client_state *csp, char **header);
 #endif /* def FEATURE_CONNECTION_KEEP_ALIVE */
 
+static jb_err client_save_content_type(struct client_state *csp, char **header);
 static jb_err client_save_content_length(struct client_state *csp, char **header);
 static jb_err client_host_adder       (struct client_state *csp);
 static jb_err client_xtra_adder       (struct client_state *csp);
@@ -188,6 +190,7 @@ static const struct parsers client_patterns[] = {
    { "TE:",                       3,   client_te },
    { "Host:",                     5,   client_host },
    { "if-modified-since:",       18,   client_if_modified_since },
+   { "Content-Type:",            13,   client_save_content_type },
    { "Content-Length:",          15,   client_save_content_length },
 #ifdef FEATURE_CONNECTION_KEEP_ALIVE
    { "Keep-Alive:",              11,   client_keep_alive },
@@ -308,7 +311,7 @@ long flush_iob(jb_socket fd, struct iob *iob, unsigned int delay)
  *                or buffer limit reached.
  *
  *********************************************************************/
-jb_err add_to_iob(struct iob *iob, const size_t buffer_limit, char *src, long n)
+jb_err add_to_iob(struct iob *iob, const size_t buffer_limit, const char *src, long n)
 {
    size_t used, offset, need;
    char *p;
@@ -1997,16 +2000,57 @@ static jb_err get_content_length(const char *header_value, unsigned long long *l
 
 /*********************************************************************
  *
+ * Function    :  client_save_content_type
+ *
+ * Description :  Save the conent type and multipart/form-data boundary sent by the client.
+ *
+ * Parameters  :
+ *          1  :  csp = Current client state (buffers, headers, etc...)
+ *          2  :  header = pointer to header to content-type header
+ *
+ * Returns     :  JB_ERR_OK on success, or
+ *                JB_ERR_MEMORY on out-of-memory error.
+ *
+ *********************************************************************/
+static jb_err client_save_content_type(struct client_state *csp, char **header)
+{
+   static const char boundary[] = "boundary=";
+   static const char multipart[] = "multipart/form-data";
+   const char *p;
+
+   assert(*(*header+12) == ':');
+
+   p = *header + 13;
+
+   if (strstr(p, "application/x-www-form-urlencoded"))
+   {
+      csp->content_type |= CT_URLENCODED;
+   }
+   else if (strstr(p, "text/"))
+   {
+      csp->content_type |= CT_TEXT;
+   }
+   else if (NULL != (p = strstr(p, multipart)))
+   {
+      p = strstr(p + sizeof(multipart) - 1, boundary);
+      if (p != NULL)
+      {
+         csp->multipart_form_boundary_start = p + sizeof(boundary) - 1;
+      }
+   }
+   return JB_ERR_OK;
+}
+
+
+/*********************************************************************
+ *
  * Function    :  client_save_content_length
  *
  * Description :  Save the Content-Length sent by the client.
  *
  * Parameters  :
  *          1  :  csp = Current client state (buffers, headers, etc...)
- *          2  :  header = On input, pointer to header to modify.
- *                On output, pointer to the modified header, or NULL
- *                to remove the header.  This function frees the
- *                original string if necessary.
+ *          2  :  header = pointer to the content-length header
  *
  * Returns     :  JB_ERR_OK on success, or
  *                JB_ERR_MEMORY on out-of-memory error.
@@ -2619,6 +2663,37 @@ static jb_err server_adjust_content_encoding(struct client_state *csp, char **he
 
 /*********************************************************************
  *
+ * Function    :  header_adjust_content_length
+ *
+ * Description :  Replace given header with new Content-Length header
+ *
+ * Parameters  :
+ *          1  :  header = On input, pointer to header to modify.
+ *                On output, pointer to the modified header, or NULL
+ *                to remove the header.  This function frees the
+ *                original string if necessary.
+ *          2  :  content_length = content length value to set
+ *
+ * Returns     :  JB_ERR_OK on success, or
+ *                JB_ERR_MEMORY on out-of-memory error.
+ *
+ *********************************************************************/
+jb_err header_adjust_content_length(char **header, size_t content_length)
+{
+   const size_t header_length = 50;
+   freez(*header);
+   *header = malloc(header_length);
+   if (*header == NULL)
+   {
+      return JB_ERR_MEMORY;
+   }
+   create_content_length_header(content_length, *header, header_length);
+   return JB_ERR_OK;
+}
+
+
+/*********************************************************************
+ *
  * Function    :  server_adjust_content_length
  *
  * Description :  Adjust Content-Length header if we modified
@@ -2640,14 +2715,10 @@ static jb_err server_adjust_content_length(struct client_state *csp, char **head
    /* Regenerate header if the content was modified. */
    if (csp->flags & CSP_FLAG_MODIFIED)
    {
-      const size_t header_length = 50;
-      freez(*header);
-      *header = malloc(header_length);
-      if (*header == NULL)
+      if (JB_ERR_OK != header_adjust_content_length(header, csp->content_length))
       {
          return JB_ERR_MEMORY;
       }
-      create_content_length_header(csp->content_length, *header, header_length);
       log_error(LOG_LEVEL_HEADER,
          "Adjusted Content-Length to %llu", csp->content_length);
    }
@@ -4932,6 +5003,86 @@ unsigned long long get_expected_content_length(struct list *headers)
    }
 
    return content_length;
+}
+
+
+/*********************************************************************
+ *
+ * Function    :  parse_url_encoded_string
+ *
+ * Description :  Parse a URL-encoded argument string into name/value
+ *                pairs and store them in a struct map list.
+ *
+ * Parameters  :
+ *          1  :  argstring = string to be parsed.  Will be trashed.
+ *
+ * Returns     :  pointer to param list, or NULL if out of memory.
+ *
+ *********************************************************************/
+struct map *parse_url_encoded_string(char *argstring)
+{
+   char *p;
+   char **vector;
+   int pairs, i;
+   struct map *cgi_params;
+
+   /*
+    * XXX: This estimate is guaranteed to be high enough as we
+    *      let ssplit() ignore empty fields, but also a bit wasteful.
+    *      The same hack is used in get_last_url() so it looks like
+    *      a real solution is needed.
+    */
+   size_t max_segments = strlen(argstring) / 2;
+   if (max_segments == 0)
+   {
+      /*
+       * XXX: If the argstring is empty, there's really
+       *      no point in creating a param list, but currently
+       *      other parts of Privoxy depend on the list's existence.
+       */
+      max_segments = 1;
+   }
+   vector = malloc_or_die(max_segments * sizeof(char *));
+
+   cgi_params = new_map();
+
+   /*
+    * IE 5 does, of course, violate RFC 2316 Sect 4.1 and sends
+    * the fragment identifier along with the request, so we must
+    * cut it off here, so it won't pollute the CGI params:
+    */
+   if (NULL != (p = strchr(argstring, '#')))
+   {
+      *p = '\0';
+   }
+
+   pairs = ssplit(argstring, "&", vector, max_segments);
+   assert(pairs != -1);
+   if (pairs == -1)
+   {
+      freez(vector);
+      free_map(cgi_params);
+      return NULL;
+   }
+
+   for (i = 0; i < pairs; i++)
+   {
+      if ((NULL != (p = strchr(vector[i], '='))) && (*(p+1) != '\0'))
+      {
+         *p = '\0';
+         if (map(cgi_params, url_decode(vector[i]), 0, url_decode(++p), 0))
+         {
+            freez(vector);
+            free_map(cgi_params);
+            return NULL;
+         }
+      }
+   }
+
+   freez(vector);
+
+   return cgi_params;
+
 }
 
 

--- a/parsers.h
+++ b/parsers.h
@@ -50,7 +50,7 @@
 #define FILTER_SERVER_HEADERS 1
 
 extern long flush_iob(jb_socket fd, struct iob *iob, unsigned int delay);
-extern jb_err add_to_iob(struct iob *iob, const size_t buffer_limit, char *src, long n);
+extern jb_err add_to_iob(struct iob *iob, const size_t buffer_limit, const char *src, long n);
 extern void clear_iob(struct iob *iob);
 extern jb_err decompress_iob(struct client_state *csp);
 extern char *get_header(struct iob *iob);
@@ -59,6 +59,7 @@ extern jb_err sed(struct client_state *csp, int filter_server_headers);
 #ifdef FEATURE_HTTPS_INSPECTION
 extern jb_err sed_https(struct client_state *csp);
 #endif
+extern jb_err header_adjust_content_length(char **header, size_t content_length);
 extern jb_err update_server_headers(struct client_state *csp);
 extern void get_http_time(int time_offset, char *buf, size_t buffer_size);
 extern jb_err get_destination_from_headers(const struct list *headers, struct http_request *http);
@@ -67,6 +68,7 @@ extern jb_err get_destination_from_https_headers(const struct list *headers, str
 #endif
 extern unsigned long long get_expected_content_length(struct list *headers);
 extern jb_err client_transfer_encoding(struct client_state *csp, char **header);
+extern struct map *parse_url_encoded_string(char *argstring);
 
 #ifdef FEATURE_FORCE_LOAD
 extern int strclean(char *string, const char *substring);

--- a/project.h
+++ b/project.h
@@ -499,9 +499,10 @@ struct iob
 
 
 /* Bits for csp->content_type bitmask: */
-#define CT_TEXT    0x0001U /**< Suitable for pcrs filtering. */
-#define CT_GIF     0x0002U /**< Suitable for GIF filtering.  */
-#define CT_TABOO   0x0004U /**< DO NOT filter, irrespective of other flags. */
+#define CT_TEXT         0x0001U /**< Suitable for pcrs filtering. */
+#define CT_GIF          0x0002U /**< Suitable for GIF filtering.  */
+#define CT_TABOO        0x0004U /**< DO NOT filter, irrespective of other flags. */
+#define CT_URLENCODED   0x0008U /**< application/x-www-form-urlencoded content */
 
 /* Although these are not, strictly speaking, content types
  * (they are content encodings), it is simple to handle them
@@ -655,8 +656,10 @@ struct iob
 #define ACTION_MULTI_EXTERNAL_FILTER         6
 /** Index into current_action_spec::multi[] for tags to suppress. */
 #define ACTION_MULTI_SUPPRESS_TAG            7
+/** Index into current_action_spec::multi[] for client-content filters to apply. */
+#define ACTION_MULTI_CLIENT_CONTENT_FILTER   8
 /** Number of multi-string actions. */
-#define ACTION_MULTI_COUNT                   8
+#define ACTION_MULTI_COUNT                   9
 
 
 /**
@@ -1062,6 +1065,11 @@ struct client_state
    /** List of all headers for this request */
    struct list headers[1];
 
+   /** Pointer to multipart form boundary string start.
+    *  Simply points to parsed headers list content.
+    */
+   const char *multipart_form_boundary_start;
+
 #ifdef FEATURE_HTTPS_INSPECTION
    /** List of all encrypted headers for this request */
    struct list https_headers[1];
@@ -1306,17 +1314,18 @@ enum filter_type
    FT_SERVER_HEADER_FILTER = 2,
    FT_CLIENT_HEADER_TAGGER = 3,
    FT_SERVER_HEADER_TAGGER = 4,
+   FT_SUPPRESS_TAG = 5,
+   FT_CLIENT_CONTENT_FILTER = 6,
 #ifdef FEATURE_EXTERNAL_FILTERS
-   FT_EXTERNAL_CONTENT_FILTER = 5,
+   FT_EXTERNAL_CONTENT_FILTER = 7,
 #endif
-   FT_SUPPRESS_TAG = 6,
    FT_INVALID_FILTER       = 42,
 };
 
 #ifdef FEATURE_EXTERNAL_FILTERS
-#define MAX_FILTER_TYPES        7
+#define MAX_FILTER_TYPES        8
 #else
-#define MAX_FILTER_TYPES        6
+#define MAX_FILTER_TYPES        7
 #endif
 
 /**

--- a/ssplit.c
+++ b/ssplit.c
@@ -150,8 +150,6 @@ int ssplit(char *str, const char *delim, char *vec[], size_t vec_len)
       }
    }
    /* null terminate the substring */
-   /* XXX: this shouldn't be necessary, so assert that it isn't. */
-   assert(*str == '\0');
    *str = '\0';
 
    return(vec_count);

--- a/templates/edit-actions-for-url
+++ b/templates/edit-actions-for-url
@@ -370,6 +370,19 @@ function show_limit_connect_opts(tf)
     <tr class="bg1" align="left" valign="top">
       <td class="en1">&nbsp;</td>
       <td class="dis1" align="center" valign="middle"><input type="radio"
+        name="client_content_filter_all" id="client_content_filter_all_n" value="N" @client-content-filter-all-n@ ></td>
+      <td class="noc1" align="center" valign="middle"><input type="radio"
+        name="client_content_filter_all" id="client_content_filter_all_x" value="X" @client-content-filter-all-x@ ></td>
+      <td class="action"><a href="@user-manual@@actions-help-prefix@CLIENT-CONTENT-FILTER">client-content-filter</a> *</td>
+      <td>Filter the client request content.
+        You can use the radio buttons on this line to disable
+        all client-content filters applied by previous rules, and/or
+        you can enable or disable the filters individually below.</td>
+    </tr>
+@client-content-filter-params@
+    <tr class="bg1" align="left" valign="top">
+      <td class="en1">&nbsp;</td>
+      <td class="dis1" align="center" valign="middle"><input type="radio"
         name="client_header_tagger_all" id="client_header_tagger_all_n" value="N" @client-header-tagger-all-n@ ></td>
       <td class="noc1" align="center" valign="middle"><input type="radio"
         name="client_header_tagger_all" id="client_header_tagger_all_x" value="X" @client-header-tagger-all-x@ ></td>


### PR DESCRIPTION
and client-content-filter action

TODO: it seems that we can completely remove receive_and_send_encrypted_post_data() code:
replace with flush_iob

TODO: force_client_content_text action?

- ssplit fix: do not assert in case incorrect data is received with content-type
is application/x-www-form-urlencoded (in my case crashed when actual content sent
was multiline JSON data).