### PR TITLE
Feature/client input name

### DIFF
--- a/filters.c
+++ b/filters.c
@@ -2820,9 +2820,9 @@ static int input_name_match(const struct pattern_spec *pattern,
    if (!(pattern->flags & PATTERN_SPEC_CLIENT_INPUT_NAME_PATTERN))
    {
       /*
-       * It's not a client input pattern: by default match all inputs
+       * It's not a client input pattern
        */
-      return 1;
+      return 0;
    }
 
    assert(input_name);

--- a/project.h
+++ b/project.h
@@ -485,6 +485,9 @@ struct pattern_spec
 /** Pattern spec bitmap: It's a CLIENT-TAG pattern. */
 #define PATTERN_SPEC_CLIENT_TAG_PATTERN      0x00000010UL
 
+/** Pattern spec bitmap: It's a CLIENT-INPUT-NAME pattern. */
+#define PATTERN_SPEC_CLIENT_INPUT_NAME_PATTERN 0x00000020UL
+
 /**
  * An I/O buffer.  Holds a string which can be appended to, and can have data
  * removed from the beginning.

--- a/urlmatch.c
+++ b/urlmatch.c
@@ -1208,7 +1208,8 @@ jb_err create_pattern_spec(struct pattern_spec *pattern, char *buf)
       { "CLIENT-TAG:",      11, PATTERN_SPEC_CLIENT_TAG_PATTERN},
  #endif
       { "NO-REQUEST-TAG:",  15, PATTERN_SPEC_NO_REQUEST_TAG_PATTERN},
-      { "NO-RESPONSE-TAG:", 16, PATTERN_SPEC_NO_RESPONSE_TAG_PATTERN}
+      { "NO-RESPONSE-TAG:", 16, PATTERN_SPEC_NO_RESPONSE_TAG_PATTERN},
+      { "CLIENT-INPUT-NAME:", 18, PATTERN_SPEC_CLIENT_INPUT_NAME_PATTERN}
    };
    int i;
 


### PR DESCRIPTION
quick-and-dirty POC: allows modify only specific input field by using "CLIENT-INPUT-NAME:patern" action URL pattern.