### PR TITLE
Fix for memory free crash/memory leak in free_pattern_spec()

### DIFF
--- a/urlmatch.c
+++ b/urlmatch.c
@@ -1263,6 +1263,17 @@ void free_pattern_spec(struct pattern_spec *pattern)
    if (pattern == NULL) return;
 
    freez(pattern->spec);
+
+   if (!(pattern->flags & PATTERN_SPEC_URL_PATTERN))
+   {
+      if (pattern->pattern.tag_regex)
+      {
+         regfree(pattern->pattern.tag_regex);
+         freez(pattern->pattern.tag_regex);
+      }
+      return;
+   }
+
 #ifdef FEATURE_PCRE_HOST_PATTERNS
    if (pattern->pattern.url_spec.host_regex)
    {
@@ -1278,11 +1289,6 @@ void free_pattern_spec(struct pattern_spec *pattern)
    {
       regfree(pattern->pattern.url_spec.preg);
       freez(pattern->pattern.url_spec.preg);
-   }
-   if (pattern->pattern.tag_regex)
-   {
-      regfree(pattern->pattern.tag_regex);
-      freez(pattern->pattern.tag_regex);
    }
 }
 


### PR DESCRIPTION
Steps to repoduce: go to http://config.privoxy.org/, edit user.action
file:
1. create suppress-tag action (Insert new sction it top->Edit; on the next screen
click "Enable" for suppress tag action, enter tag TEST to suppress, click submit)
2. Edit suppress-tag action: click "Edit" for section with suppress-tag action,
change "Enable" to "Disable" for "supress-tag TEST" action, click submit)
Result: core dump or valgrind memory leak error in create_pattern_spec()