### PR TITLE
Add missing #include <stddef.h> to fix the following error:

### DIFF
--- a/gateway.c
+++ b/gateway.c
@@ -37,6 +37,7 @@
 #include "config.h"
 
 #include <stdio.h>
+#include <stddef.h>
 #include <sys/types.h>
 
 #ifndef _WIN32


### PR DESCRIPTION
gateway.c:845:18: error: call to undeclared function 'offsetof'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]

The build was done on macOS and privoxy was configured without openssl and brotli:

```
CPPFLAGS=-I/opt/local/include LDFLAGS=-L/opt/local/lib ./configure
```

The error does not happen when privoxy is configure with --with-openssl